### PR TITLE
Site style tweaks

### DIFF
--- a/.dev/sass/mixins/_global.scss
+++ b/.dev/sass/mixins/_global.scss
@@ -385,6 +385,7 @@ $cursor-text-value: text !default;
 			line-height: $base-line-height; // Set to $base-line-height to take on browser default of 1.8
 			cursor: $cursor-default-value;
 			-webkit-font-smoothing: antialiased;
+			word-wrap: break-word;
 		}
 
 	a:hover { cursor: $cursor-pointer-value; }

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -243,7 +243,6 @@ body.no-max-width .main-navigation {
 
 		margin-bottom: 1em;
 		margin-bottom: 1rem;
-		padding: 0;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -67,7 +67,8 @@ body {
   font-style: normal;
   line-height: 1.8;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -165,7 +166,8 @@ body {
   font-style: normal;
   line-height: 1.8;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -2336,8 +2338,7 @@ body.no-max-width .main-navigation {
  */
 .navigation .nav-links {
   margin-bottom: 1em;
-  margin-bottom: 1rem;
-  padding: 0; }
+  margin-bottom: 1rem; }
 
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,

--- a/style.css
+++ b/style.css
@@ -67,7 +67,8 @@ body {
   font-style: normal;
   line-height: 1.8;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -165,7 +166,8 @@ body {
   font-style: normal;
   line-height: 1.8;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -2336,8 +2338,7 @@ body.no-max-width .main-navigation {
  */
 .navigation .nav-links {
   margin-bottom: 1em;
-  margin-bottom: 1rem;
-  padding: 0; }
+  margin-bottom: 1rem; }
 
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,


### PR DESCRIPTION
- Add word-wrap to the body to prevent lengthy words from overflowing outside the container.
- Tweak the post/page navigation padding to match the content wrapper width.