### PR TITLE
Tweak hero text widget p font-size

### DIFF
--- a/.dev/sass/partials/_widgets.scss
+++ b/.dev/sass/partials/_widgets.scss
@@ -227,3 +227,11 @@ $widget-bg: #fff !default;
 #content .widget ul li {
 	border: none;
 }
+
+.hero .widget.widget_text p {
+	font-size: 2.625rem;
+	font-weight: lighter;
+	font-style: normal;
+	padding: 0;
+	line-height: 1.25;
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2584,6 +2584,13 @@ body.no-max-width .main-navigation {
 #content .widget ul li {
   border: none; }
 
+.hero .widget.widget_text p {
+  font-size: 2.625rem;
+  font-weight: lighter;
+  font-style: normal;
+  padding: 0;
+  line-height: 1.25; }
+
 .no-results .page-header,
 .not-found .page-header {
   margin-bottom: 1em; }

--- a/style.css
+++ b/style.css
@@ -2584,6 +2584,13 @@ body.no-max-width .main-navigation {
 #content .widget ul li {
   border: none; }
 
+.hero .widget.widget_text p {
+  font-size: 2.625rem;
+  font-weight: lighter;
+  font-style: normal;
+  padding: 0;
+  line-height: 1.25; }
+
 .no-results .page-header,
 .not-found .page-header {
   margin-bottom: 1em; }


### PR DESCRIPTION
Adjust the hero text widget p font size, so that it better fits the feel of the theme. Requires little markup to be added to the text widget.

Before:
![Example - Before](https://cldup.com/yAbNRgDa8K.png)

After:
![Example - After](https://cldup.com/t2NCs56hWI.png)