### PR TITLE
Update Primer hook priorities 

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -47,7 +47,7 @@ ul.site-header-cart.menu {
 
 }
 
-.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
 	padding: 0;
 	margin: 0;
 	width: 100%;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,125 +1,114 @@
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-    float: right;
-    min-width: 275px;
-    text-align: right;
-    border-bottom: none;
-}
-
-.main-navigation .menu-item-object-cart a {
-    padding-left: 0;
-    float: right;
-    cursor: pointer;
-}
-
-.main-navigation .menu-item-object-cart a i {
-    font-size: 20px;
-}
-
 .main-navigation .menu-item-object-cart:hover a {
-    background: transparent;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-    float: left;
-    margin-right: 1rem;
-    font-weight: bold;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-    float: left;
-    font-weight: 200;
+	background: transparent;
 }
 
 ul.site-header-cart.menu {
-    width: 100%;
-    max-width: 275px;
-    padding: 0;
-    list-style: none;
-    float: right;
-    display: none;
-    position: relative;
-    z-index: 10001;
-		background-color: $body-bg;
+	width: 100%;
+	max-width: 275px;
+	padding: 0;
+	list-style: none;
+	float: right;
+	display: none;
+	position: relative;
+	z-index: 10001;
+	background-color: $body-bg;
 }
 
-ul.site-header-cart.menu li {
-    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-    -webkit-box-shadow: 0 0 10px 0 grey;
-    box-shadow: 0 0 10px 0 grey;
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+	display: none;
 }
 
-ul.site-header-cart.menu ul.product_list_widget li {
-    border: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+.widget_shopping_cart {
+
+	float: left;
+	padding: 0 1rem;
+	margin-bottom: .5em;
+
+	.quantity {
+		font-style: italic;
+	}
+
+	ul.product_list_widget {
+		position: relative !important;
+		left: 0;
+	}
+
+	p.buttons,
+	.total,
+	.product_list_widget {
+		float: left;
+		width: 100%;
+	}
+
+	p.buttons {
+		margin-bottom: 0;
+	}
+
 }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-    line-height: 20px;
-    padding-bottom: .25em;
+.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+	padding: 0;
+	margin: 0;
+	width: 100%;
+	padding-bottom: 5px;
+	border-bottom: none;
+
+	a:nth-child(2) {
+		padding: .5em 0em;
+		margin: 0;
+		width: 100%;
+	}
 }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
-    line-height: 2px;
-		margin-top: 8px;
+.woocommerce-cart-menu-item {
+
+	.product_list_widget {
+		border: none;
+		box-shadow: none;
+	}
+
+	.widget_shopping_cart {
+
+		.total {
+			margin: 10px 0;
+			padding-top: 10px;
+		}
+
+		p.buttons a {
+			text-align: center;
+			width: 100%;
+
+			&:first-child {
+				margin-bottom: 5px;
+			}
+
+		}
+
+	}
+
+	.cart-preview-count {
+		margin-left: 8px;
+	}
+
+	.cart_list li a.remove {
+		position: relative;
+		float: left;
+		padding: 0;
+		margin-top: 10px;
+		text-indent: 0;
+
+		&:hover {
+			background: red;
+		}
+	}
+
 }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-    margin-bottom: 0;
-    padding: 10px 0 2px 0;
-}
+@media #{$medium-up} {
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-    padding: 0 .5em;
-    max-height: 220px;
-    overflow-y: auto;
-}
+	li#woocommerce-cart-menu-item .sub-menu {
+		margin-left: -6em;
+	}
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-    width: 55px;
-    -webkit-border-radius: 5px;
-    border-radius: 5px;
-}
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-    padding: 10px;
-    margin: .5em 0;
-}
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-    padding: 0 .5em;
-    margin: 0;
-}
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-    display: block;
-    width: 100%;
-    text-align: center;
-}
-
-.site-header-cart-container {
-    width: 100%;
-    display: block;
-    max-width: 1100px;
-    margin: 0 auto;
-    position: absolute;
-    right: 0;
-    left: 0;
-}
-
-.site-header-cart-container .buttons a {
-    margin-bottom: 5px;
-}
-
-body.woocommerce .quantity input.input-text.qty {
-	padding: .45em;
-}
-
-@media only screen and (max-width: 61.063em) {
-    .menu-item-object-cart {
-        display: none;
-    }
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,0 +1,124 @@
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+    float: right;
+    min-width: 275px;
+    text-align: right;
+    border-bottom: none;
+}
+
+.main-navigation .menu-item-object-cart a {
+    padding-left: 0;
+    float: right;
+    cursor: pointer;
+}
+
+.main-navigation .menu-item-object-cart a i {
+    font-size: 20px;
+}
+
+.main-navigation .menu-item-object-cart:hover a {
+    background: transparent;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+    float: left;
+    margin-right: 1rem;
+    font-weight: bold;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+    float: left;
+    font-weight: 200;
+}
+
+ul.site-header-cart.menu {
+    width: 100%;
+    max-width: 275px;
+    padding: 0;
+    list-style: none;
+    float: right;
+    display: none;
+    position: relative;
+    z-index: 10001;
+		background-color: $body-bg;
+}
+
+ul.site-header-cart.menu li {
+    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+    -webkit-box-shadow: 0 0 10px 0 grey;
+    box-shadow: 0 0 10px 0 grey;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
+    margin: 8px 0;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
+    line-height: 20px;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
+    line-height: 2px;
+		margin-top: 8px;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart {
+    margin-bottom: 0;
+    padding: 10px 0 2px 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+    padding: 0 .5em;
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+    width: 55px;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+    padding: 10px;
+    margin: .5em 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+    padding: 0 .5em;
+    margin: 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+    display: block;
+    width: 100%;
+    text-align: center;
+}
+
+.site-header-cart-container {
+    width: 100%;
+    display: block;
+    max-width: 1100px;
+    margin: 0 auto;
+    position: absolute;
+    right: 0;
+    left: 0;
+}
+
+.site-header-cart-container .buttons a {
+    margin-bottom: 5px;
+}
+
+@media only screen and (max-width: 61.063em) {
+    .menu-item-object-cart {
+        display: none;
+    }
+}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -45,6 +45,7 @@
 
 			p.buttons {
 				padding: .5em;
+				padding-top: 0;
 				margin: 0;
 			}
 
@@ -99,8 +100,8 @@
 				margin-bottom: 0;
 
 				.total {
-					margin: 0 0 10px 0;
-					padding-top: 10px;
+					margin: 0;
+					padding: 10px 0;
 					text-align: center;
 				}
 
@@ -196,25 +197,27 @@ body.woocommerce-cart {
 	}
 }
 
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-	width: 100%;
-	max-width: 100px;
-	margin-bottom: 0;
-}
+.woocommerce,
+.woocommerce-page {
 
-.woocommerce #content table.cart td.actions .input-text,
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-	padding: 6px;
+	table.cart {
+
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 6px !important;
+		}
+
+	}
+
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
 	width: 100%;
-	font-size: 16px;
 	text-align: center;
 }
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -59,6 +59,7 @@ ul.site-header-cart.menu ul.product_list_widget li {
 
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
     line-height: 20px;
+    padding-bottom: .25em;
 }
 
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -53,12 +53,22 @@ ul.site-header-cart.menu {
 	width: 100%;
 	padding-bottom: 5px;
 	border-bottom: none;
+	opacity: 1;
+	transition: opacity .25s ease-out;
+	-moz-transition: opacity .25s ease-out;
+	-webkit-transition: opacity .25s ease-out;
+	-o-transition: opacity .25s ease-out;
 
 	a:nth-child(2) {
 		padding: .5em 0em;
 		margin: 0;
 		width: 100%;
 	}
+
+	&:hover {
+		opacity: 0.85;
+	}
+
 }
 
 .woocommerce-cart-menu-item {
@@ -109,6 +119,42 @@ ul.site-header-cart.menu {
 
 	li#woocommerce-cart-menu-item .sub-menu {
 		margin-left: -6em;
+	}
+
+}
+
+@media #{$small-only} {
+
+	li#woocommerce-cart-menu-item {
+		display: inline-block;
+		width: 100%;
+	}
+
+	.widget_shopping_cart {
+
+		width: 100%;
+
+		ul.product_list_widget,
+		.woocommerce-cart-menu-item {
+			display: block;
+			width: 100%;
+		}
+
+		.cart_list li.mini_cart_item a:nth-child(2) {
+
+			border: none;
+
+			img {
+				width: 100%;
+				max-width: 55px;
+			}
+
+		}
+
+		.total {
+			text-align: center;
+		}
+
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -114,6 +114,10 @@ ul.site-header-cart.menu .widget_shopping_cart .buttons a {
     margin-bottom: 5px;
 }
 
+body.woocommerce .quantity input.input-text.qty {
+	padding: .45em;
+}
+
 @media only screen and (max-width: 61.063em) {
     .menu-item-object-cart {
         display: none;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -32,6 +32,8 @@ ul.site-header-cart.menu {
 	ul.product_list_widget {
 		position: relative !important;
 		left: 0;
+		max-height: 250px;
+		overflow-y: auto;
 	}
 
 	p.buttons,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,160 +1,233 @@
-.main-navigation .menu-item-object-cart:hover a {
-	background: transparent;
-}
+.primer-wc-cart-menu {
 
-ul.site-header-cart.menu {
-	width: 100%;
-	max-width: 275px;
-	padding: 0;
-	list-style: none;
-	float: right;
-	display: none;
-	position: relative;
-	z-index: 10001;
-	background-color: $body-bg;
-}
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-	display: none;
-}
-
-.widget_shopping_cart {
-
-	float: left;
-	padding: 0 1rem;
-	margin-bottom: .5em;
-
-	.quantity {
-		font-style: italic;
-	}
-
-	ul.product_list_widget {
-		position: relative !important;
-		left: 0;
-		max-height: 250px;
-		overflow-y: auto;
-	}
-
-	p.buttons,
-	.total,
-	.product_list_widget {
-		float: left;
+	.primer-wc-cart-sub-menu {
+		float: right;
 		width: 100%;
-	}
-
-	p.buttons {
-		margin-bottom: 0;
-	}
-
-}
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-	padding: 0;
-	margin: 0;
-	width: 100%;
-	padding-bottom: 5px;
-	border-bottom: none;
-	opacity: 1;
-	transition: opacity .25s ease-out;
-	-moz-transition: opacity .25s ease-out;
-	-webkit-transition: opacity .25s ease-out;
-	-o-transition: opacity .25s ease-out;
-
-	a:nth-child(2) {
-		padding: .5em 0em;
-		margin: 0;
-		width: 100%;
-	}
-
-	&:hover {
-		opacity: 0.85;
-	}
-
-}
-
-.woocommerce-cart-menu-item {
-
-	.product_list_widget {
-		border: none;
 		box-shadow: none;
-	}
 
-	.widget_shopping_cart {
-
-		.total {
-			margin: 10px 0;
-			padding-top: 10px;
+		li,
+		.widget_shopping_cart {
+			width: 100%;
+			background: #fff;
 		}
 
-		p.buttons a {
-			text-align: center;
-			width: 100%;
+		.widget_shopping_cart {
 
-			&:first-child {
-				margin-bottom: 5px;
+			float: right;
+			width: 250px;
+			box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+
+			.quantity {
+				display: block;
+				float: left;
+				font-style: italic;
+				padding-left: 1.25em;
+				padding-bottom: .5em;
+			}
+
+			ul.product_list_widget {
+				position: relative !important;
+				left: 0;
+				max-height: 250px;
+				overflow-y: auto;
+			}
+
+			p.buttons,
+			.total,
+			.product_list_widget {
+				float: left;
+				width: 100%;
+			}
+
+			.total strong {
+				text-index: 0;
+			}
+
+			p.buttons {
+				padding: .5em;
+				margin: 0;
+			}
+
+			.cart_list li.mini_cart_item {
+				padding: 0 !important;
+				margin: 0;
+				width: 100%;
+				padding-bottom: 5px;
+				border-bottom: none;
+				padding: .5em 1em;
+				text-indent: 0;
+				opacity: 1;
+				transition: opacity .25s ease-out;
+
+				img {
+					width: 100%;
+					max-width: 55px;
+				}
+
+				a {
+					border-bottom: none;
+				}
+
+				a:nth-child(2) {
+					padding: .5em;
+					padding-bottom :0;
+					margin: 0;
+					width: 100%;
+					text-indent: 0 !important;
+				}
+
+				&:hover {
+					opacity: .85;
+				}
+			}
+
+		}
+
+		.primer-wc-cart-sub-menu-item {
+
+			.product_list_widget {
+				border: none;
+				box-shadow: none;
+				display: inline-block;
+				left: 0 !important;
+				background: inherit;
+			}
+
+			.widget_shopping_cart {
+
+				padding: 0;
+				margin-bottom: 0;
+
+				.total {
+					margin: 0 0 10px 0;
+					padding-top: 10px;
+					text-align: center;
+				}
+
+				.total strong {
+					text-indent: 0;
+				}
+
+				p.buttons a {
+					text-align: center;
+					width: 100%;
+					text-indent: 0;
+
+					&:first-child {
+						margin-bottom: 5px;
+					}
+
+				}
+
+			}
+
+			.cart-preview-count {
+				margin-left: 8px;
+			}
+
+			.cart_list li a.remove {
+				position: relative !important;
+				float: left;
+				padding: 0;
+				margin-top: 10px;
+				margin-left: 15px;
+				text-indent: 0;
+				margin-right: 5px;
+				z-index: 1001;
+				line-height: .95;
+				text-indent: 0 !important;
+				border: none;
+				box-shadow: none;
+
+				&:hover {
+					background: red !important;
+				}
 			}
 
 		}
 
 	}
 
-	.cart-preview-count {
-		margin-left: 8px;
-	}
+	&:hover {
+		cursor: pointer;
 
-	.cart_list li a.remove {
-		position: relative;
-		float: left;
-		padding: 0;
-		margin-top: 10px;
-		text-indent: 0;
-
-		&:hover {
-			background: red;
+		a {
+			background: transparent;
 		}
+
 	}
 
 }
 
-@media #{$medium-up} {
+body.post-type-archive,
+body.single-product {
 
-	li#woocommerce-cart-menu-item .sub-menu {
-		margin-left: -6em;
+	/* On Sale Badge */
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
 	}
 
+}
+
+body.single-product {
+
+	span.onsale {
+		padding: 3px 18px;
+		top: 0;
+		left: 0;
+	}
+
+	.quantity .input-text {
+		padding: 8px;
+	}
+
+}
+
+body.woocommerce-cart {
+
+	.primer-wc-cart-sub-menu {
+		display: none;
+	}
+}
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+	width: 100%;
+	max-width: 100px;
+	margin-bottom: 0;
+}
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+	padding: 6px;
+}
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+	width: 100%;
+	font-size: 16px;
+	text-align: center;
 }
 
 @media #{$small-only} {
 
-	li#woocommerce-cart-menu-item {
-		display: inline-block;
-		width: 100%;
-	}
+	.primer-wc-cart-menu {
 
-	.widget_shopping_cart {
+		.primer-wc-cart-sub-menu {
 
-		width: 100%;
-
-		ul.product_list_widget,
-		.woocommerce-cart-menu-item {
-			display: block;
-			width: 100%;
-		}
-
-		.cart_list li.mini_cart_item a:nth-child(2) {
-
-			border: none;
-
-			img {
+			.widget_shopping_cart {
 				width: 100%;
-				max-width: 55px;
 			}
 
-		}
-
-		.total {
-			text-align: center;
 		}
 
 	}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -57,10 +57,6 @@ ul.site-header-cart.menu ul.product_list_widget li {
     box-shadow: none;
 }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
-    margin: 8px 0;
-}
-
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
     line-height: 20px;
 }

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -41,3 +41,4 @@
 @import "partials/genericons";
 @import "partials/social";
 @import "partials/jetpack";
+@import "compat/woocommerce";

--- a/functions.php
+++ b/functions.php
@@ -18,11 +18,9 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
 function ascension_move_elements() {
 
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
-	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 
-	add_action( 'primer_after_header', 'primer_generate_cart_submenu',  5 );
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 
@@ -212,6 +210,11 @@ function ascension_colors( $colors ) {
 		),
 		'button_color' => array(
 			'default'  => '#00bfff',
+			'css'     => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+					'background-color' => '%1$s',
+				)
+			),
 		),
 		'button_text_color' => array(
 			'default'  => '#ffffff',

--- a/functions.php
+++ b/functions.php
@@ -17,11 +17,11 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
  */
 function ascension_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero', 7 );
+	remove_action( 'primer_header',       'primer_add_hero',               7 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
-	remove_action( 'primer_after_header', 'primer_add_page_title', 12 );
+	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 
-	add_action( 'primer_after_header', 'primer_add_hero', 7 );
+	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {

--- a/functions.php
+++ b/functions.php
@@ -18,11 +18,11 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
 function ascension_move_elements() {
 
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
-	remove_action( 'primer_after_header', 'primer_generate_cart_submenu', 11 );
+	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 
-	add_action( 'primer_after_header', 'primer_generate_cart_submenu', 5 );
+	add_action( 'primer_after_header', 'primer_generate_cart_submenu',  5 );
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 

--- a/functions.php
+++ b/functions.php
@@ -17,16 +17,16 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
  */
 function ascension_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero' );
-	remove_action( 'primer_after_header', 'primer_add_primary_navigation' );
-	remove_action( 'primer_after_header', 'primer_add_page_title' );
+	remove_action( 'primer_header',       'primer_add_hero', 7 );
+	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
+	remove_action( 'primer_after_header', 'primer_add_page_title', 12 );
 
-	add_action( 'primer_after_header', 'primer_add_hero' );
-	add_action( 'primer_header',       'primer_add_primary_navigation' );
+	add_action( 'primer_after_header', 'primer_add_hero', 7 );
+	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
-		add_action( 'primer_hero', 'primer_add_page_title' );
+		add_action( 'primer_hero', 'primer_add_page_title', 12 );
 
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -18,9 +18,11 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
 function ascension_move_elements() {
 
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
+	remove_action( 'primer_after_header', 'primer_generate_cart_submenu', 11 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 
+	add_action( 'primer_after_header', 'primer_generate_cart_submenu', 5 );
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 

--- a/functions.php
+++ b/functions.php
@@ -213,7 +213,7 @@ function ascension_colors( $colors ) {
 			'css'     => array(
 				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
 					'background-color' => '%1$s',
-				)
+				),
 			),
 		),
 		'button_text_color' => array(

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4095,6 +4095,7 @@ body.layout-one-column-narrow #content {
       text-index: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
       padding: .5em;
+      padding-top: 0;
       margin: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
       padding: 0 !important;
@@ -4131,8 +4132,8 @@ body.layout-one-column-narrow #content {
     padding: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
-      margin: 0 0 10px 0;
-      padding-top: 10px;
+      margin: 0;
+      padding: 10px 0;
       text-align: center; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
       text-indent: 0; }
@@ -4192,23 +4193,18 @@ body.single-product .quantity .input-text {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 6px; }
+  padding: 6px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  font-size: 16px;
   text-align: center; }
 
 @media only screen and (max-width: 40em) {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4061,106 +4061,156 @@ body.layout-one-column-narrow #content {
 #wpstats {
   display: none; }
 
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
-
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   float: left;
-  display: none;
-  position: relative;
-  z-index: 10001;
-  background-color: #fff; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
-  float: right;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
-    font-style: italic; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    right: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: right;
-    width: 100%; }
-  .widget_shopping_cart p.buttons {
-    margin-bottom: 0; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0;
-  margin: 0;
   width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em 0em;
-    margin: 0;
-    width: 100%; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: 0.85; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart .total {
-  margin: 10px 0;
-  padding-top: 10px; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-  text-align: center;
-  width: 100%; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-    margin-bottom: 5px; }
-
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-right: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
-  float: right;
-  padding: 0;
-  margin-top: 10px;
-  text-indent: 0; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red; }
-
-@media only screen and (min-width: 40.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-right: -6em; } }
-
-@media only screen and (max-width: 40em) {
-  li#woocommerce-cart-menu-item {
-    display: inline-block;
-    width: 100%; }
-  .widget_shopping_cart {
-    width: 100%; }
-    .widget_shopping_cart ul.product_list_widget,
-    .widget_shopping_cart .woocommerce-cart-menu-item {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%;
+    background: #fff; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    float: left;
+    width: 250px;
+    -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .quantity {
       display: block;
+      float: right;
+      font-style: italic;
+      padding-right: 1.25em;
+      padding-bottom: .5em; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
+      position: relative !important;
+      right: 0;
+      max-height: 250px;
+      overflow-y: auto; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .product_list_widget {
+      float: right;
       width: 100%; }
-    .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-      border: none; }
-      .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
+      padding: .5em;
+      margin: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0 !important;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
         width: 100%;
         max-width: 55px; }
-    .widget_shopping_cart .total {
-      text-align: center; } }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em;
+        padding-bottom: 0;
+        margin: 0;
+        width: 100%;
+        text-indent: 0 !important; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    right: 0 !important;
+    background: inherit; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart {
+    padding: 0;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
+      margin: 0 0 10px 0;
+      padding-top: 10px;
+      text-align: center; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
+      text-indent: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart-preview-count {
+    margin-right: 8px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove {
+    position: relative !important;
+    float: right;
+    padding: 0;
+    margin-top: 10px;
+    margin-right: 15px;
+    text-indent: 0;
+    margin-left: 5px;
+    z-index: 1001;
+    line-height: .95;
+    text-indent: 0 !important;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove:hover {
+      background: red !important; }
+
+.primer-wc-cart-menu:hover {
+  cursor: pointer; }
+  .primer-wc-cart-menu:hover a {
+    background: transparent; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  right: 0; }
+
+body.single-product .quantity .input-text {
+  padding: 8px; }
+
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 6px; }
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
+
+@media only screen and (max-width: 40em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4112,7 +4112,8 @@ ul.site-header-cart.menu ul.product_list_widget li {
   box-shadow: none; }
 
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-  line-height: 20px; }
+  line-height: 20px;
+  padding-bottom: .25em; }
 
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
   line-height: 2px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4061,34 +4061,8 @@ body.layout-one-column-narrow #content {
 #wpstats {
   display: none; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: left;
-  min-width: 275px;
-  text-align: left;
-  border-bottom: none; }
-
-.main-navigation .menu-item-object-cart a {
-  padding-right: 0;
-  float: left;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: right;
-  margin-left: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: right;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -4101,66 +4075,65 @@ ul.site-header-cart.menu {
   z-index: 10001;
   background-color: #fff; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: right;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    font-style: italic; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    right: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: right;
+    width: 100%; }
+  .widget_shopping_cart p.buttons {
+    margin-bottom: 0; }
+
+.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em 0em;
+    margin: 0;
+    width: 100%; }
+
+.woocommerce-cart-menu-item .product_list_widget {
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-  line-height: 20px;
-  padding-bottom: .25em; }
+.woocommerce-cart-menu-item .widget_shopping_cart .total {
+  margin: 10px 0;
+  padding-top: 10px; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
-  line-height: 2px;
-  margin-top: 8px; }
+.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+  text-align: center;
+  width: 100%; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+    margin-bottom: 5px; }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-right: 8px; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: right;
+  padding: 0;
+  margin-top: 10px;
+  text-indent: 0; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
-  text-align: center; }
-
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  left: 0;
-  right: 0; }
-
-.site-header-cart-container .buttons a {
-  margin-bottom: 5px; }
-
-body.woocommerce .quantity input.input-text.qty {
-  padding: .45em; }
-
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-right: -6em; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4096,16 +4096,23 @@ ul.site-header-cart.menu {
   .widget_shopping_cart p.buttons {
     margin-bottom: 0; }
 
-.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
   padding: 0;
   margin: 0;
   width: 100%;
   padding-bottom: 5px;
-  border-bottom: none; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+  border-bottom: none;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
     padding: .5em 0em;
     margin: 0;
     width: 100%; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: 0.85; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4137,3 +4144,21 @@ ul.site-header-cart.menu {
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-right: -6em; } }
+
+@media only screen and (max-width: 40em) {
+  li#woocommerce-cart-menu-item {
+    display: inline-block;
+    width: 100%; }
+  .widget_shopping_cart {
+    width: 100%; }
+    .widget_shopping_cart ul.product_list_widget,
+    .widget_shopping_cart .woocommerce-cart-menu-item {
+      display: block;
+      width: 100%; }
+    .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+      border: none; }
+      .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+        width: 100%;
+        max-width: 55px; }
+    .widget_shopping_cart .total {
+      text-align: center; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4111,9 +4111,6 @@ ul.site-header-cart.menu ul.product_list_widget li {
   -webkit-box-shadow: none;
   box-shadow: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
-  margin: 8px 0; }
-
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
   line-height: 20px; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4060,3 +4060,106 @@ body.layout-one-column-narrow #content {
 
 #wpstats {
   display: none; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: left;
+  min-width: 275px;
+  text-align: left;
+  border-bottom: none; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-right: 0;
+  float: left;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: right;
+  margin-left: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: right;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: left;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background-color: #fff; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
+  margin: 8px 0; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
+  line-height: 20px; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
+  line-height: 2px;
+  margin-top: 8px; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  left: 0;
+  right: 0; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4158,6 +4158,9 @@ ul.site-header-cart.menu .widget_shopping_cart .buttons a {
 .site-header-cart-container .buttons a {
   margin-bottom: 5px; }
 
+body.woocommerce .quantity input.input-text.qty {
+  padding: .45em; }
+
 @media only screen and (max-width: 61.063em) {
   .menu-item-object-cart {
     display: none; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4087,7 +4087,9 @@ ul.site-header-cart.menu {
     font-style: italic; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    right: 0; }
+    right: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {

--- a/style.css
+++ b/style.css
@@ -4095,6 +4095,7 @@ body.layout-one-column-narrow #content {
       text-index: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
       padding: .5em;
+      padding-top: 0;
       margin: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
       padding: 0 !important;
@@ -4131,8 +4132,8 @@ body.layout-one-column-narrow #content {
     padding: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
-      margin: 0 0 10px 0;
-      padding-top: 10px;
+      margin: 0;
+      padding: 10px 0;
       text-align: center; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
       text-indent: 0; }
@@ -4192,23 +4193,18 @@ body.single-product .quantity .input-text {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 6px; }
+  padding: 6px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  font-size: 16px;
   text-align: center; }
 
 @media only screen and (max-width: 40em) {

--- a/style.css
+++ b/style.css
@@ -4112,7 +4112,8 @@ ul.site-header-cart.menu ul.product_list_widget li {
   box-shadow: none; }
 
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-  line-height: 20px; }
+  line-height: 20px;
+  padding-bottom: .25em; }
 
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
   line-height: 2px;

--- a/style.css
+++ b/style.css
@@ -4111,9 +4111,6 @@ ul.site-header-cart.menu ul.product_list_widget li {
   -webkit-box-shadow: none;
   box-shadow: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
-  margin: 8px 0; }
-
 ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
   line-height: 20px; }
 

--- a/style.css
+++ b/style.css
@@ -4060,3 +4060,106 @@ body.layout-one-column-narrow #content {
 
 #wpstats {
   display: none; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: right;
+  min-width: 275px;
+  text-align: right;
+  border-bottom: none; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-left: 0;
+  float: right;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: left;
+  margin-right: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: left;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: right;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background-color: #fff; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
+  margin: 8px 0; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
+  line-height: 20px; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
+  line-height: 2px;
+  margin-top: 8px; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  right: 0;
+  left: 0; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style.css
+++ b/style.css
@@ -4158,6 +4158,9 @@ ul.site-header-cart.menu .widget_shopping_cart .buttons a {
 .site-header-cart-container .buttons a {
   margin-bottom: 5px; }
 
+body.woocommerce .quantity input.input-text.qty {
+  padding: .45em; }
+
 @media only screen and (max-width: 61.063em) {
   .menu-item-object-cart {
     display: none; } }

--- a/style.css
+++ b/style.css
@@ -4061,106 +4061,156 @@ body.layout-one-column-narrow #content {
 #wpstats {
   display: none; }
 
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
-
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   float: right;
-  display: none;
-  position: relative;
-  z-index: 10001;
-  background-color: #fff; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
-  float: left;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
-    font-style: italic; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    left: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: left;
-    width: 100%; }
-  .widget_shopping_cart p.buttons {
-    margin-bottom: 0; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0;
-  margin: 0;
   width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em 0em;
-    margin: 0;
-    width: 100%; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: 0.85; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart .total {
-  margin: 10px 0;
-  padding-top: 10px; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-  text-align: center;
-  width: 100%; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-    margin-bottom: 5px; }
-
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-left: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
-  float: left;
-  padding: 0;
-  margin-top: 10px;
-  text-indent: 0; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red; }
-
-@media only screen and (min-width: 40.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-left: -6em; } }
-
-@media only screen and (max-width: 40em) {
-  li#woocommerce-cart-menu-item {
-    display: inline-block;
-    width: 100%; }
-  .widget_shopping_cart {
-    width: 100%; }
-    .widget_shopping_cart ul.product_list_widget,
-    .widget_shopping_cart .woocommerce-cart-menu-item {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%;
+    background: #fff; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    float: right;
+    width: 250px;
+    -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .quantity {
       display: block;
+      float: left;
+      font-style: italic;
+      padding-left: 1.25em;
+      padding-bottom: .5em; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
+      position: relative !important;
+      left: 0;
+      max-height: 250px;
+      overflow-y: auto; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .product_list_widget {
+      float: left;
       width: 100%; }
-    .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-      border: none; }
-      .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
+      padding: .5em;
+      margin: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0 !important;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
         width: 100%;
         max-width: 55px; }
-    .widget_shopping_cart .total {
-      text-align: center; } }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em;
+        padding-bottom: 0;
+        margin: 0;
+        width: 100%;
+        text-indent: 0 !important; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    left: 0 !important;
+    background: inherit; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart {
+    padding: 0;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
+      margin: 0 0 10px 0;
+      padding-top: 10px;
+      text-align: center; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
+      text-indent: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart-preview-count {
+    margin-left: 8px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove {
+    position: relative !important;
+    float: left;
+    padding: 0;
+    margin-top: 10px;
+    margin-left: 15px;
+    text-indent: 0;
+    margin-right: 5px;
+    z-index: 1001;
+    line-height: .95;
+    text-indent: 0 !important;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove:hover {
+      background: red !important; }
+
+.primer-wc-cart-menu:hover {
+  cursor: pointer; }
+  .primer-wc-cart-menu:hover a {
+    background: transparent; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  left: 0; }
+
+body.single-product .quantity .input-text {
+  padding: 8px; }
+
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 6px; }
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
+
+@media only screen and (max-width: 40em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -4087,7 +4087,9 @@ ul.site-header-cart.menu {
     font-style: italic; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    left: 0; }
+    left: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {

--- a/style.css
+++ b/style.css
@@ -4096,16 +4096,23 @@ ul.site-header-cart.menu {
   .widget_shopping_cart p.buttons {
     margin-bottom: 0; }
 
-.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
   padding: 0;
   margin: 0;
   width: 100%;
   padding-bottom: 5px;
-  border-bottom: none; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+  border-bottom: none;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
     padding: .5em 0em;
     margin: 0;
     width: 100%; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: 0.85; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4137,3 +4144,21 @@ ul.site-header-cart.menu {
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-left: -6em; } }
+
+@media only screen and (max-width: 40em) {
+  li#woocommerce-cart-menu-item {
+    display: inline-block;
+    width: 100%; }
+  .widget_shopping_cart {
+    width: 100%; }
+    .widget_shopping_cart ul.product_list_widget,
+    .widget_shopping_cart .woocommerce-cart-menu-item {
+      display: block;
+      width: 100%; }
+    .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+      border: none; }
+      .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+        width: 100%;
+        max-width: 55px; }
+    .widget_shopping_cart .total {
+      text-align: center; } }

--- a/style.css
+++ b/style.css
@@ -4061,34 +4061,8 @@ body.layout-one-column-narrow #content {
 #wpstats {
   display: none; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: right;
-  min-width: 275px;
-  text-align: right;
-  border-bottom: none; }
-
-.main-navigation .menu-item-object-cart a {
-  padding-left: 0;
-  float: right;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: left;
-  margin-right: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: left;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -4101,66 +4075,65 @@ ul.site-header-cart.menu {
   z-index: 10001;
   background-color: #fff; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: left;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    font-style: italic; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    left: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: left;
+    width: 100%; }
+  .widget_shopping_cart p.buttons {
+    margin-bottom: 0; }
+
+.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em 0em;
+    margin: 0;
+    width: 100%; }
+
+.woocommerce-cart-menu-item .product_list_widget {
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-  line-height: 20px;
-  padding-bottom: .25em; }
+.woocommerce-cart-menu-item .widget_shopping_cart .total {
+  margin: 10px 0;
+  padding-top: 10px; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
-  line-height: 2px;
-  margin-top: 8px; }
+.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+  text-align: center;
+  width: 100%; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+    margin-bottom: 5px; }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-left: 8px; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: left;
+  padding: 0;
+  margin-top: 10px;
+  text-indent: 0; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
-  text-align: center; }
-
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  right: 0;
-  left: 0; }
-
-.site-header-cart-container .buttons a {
-  margin-bottom: 5px; }
-
-body.woocommerce .quantity input.input-text.qty {
-  padding: .45em; }
-
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-left: -6em; } }


### PR DESCRIPTION
The new version of primer add's priorities to some functions to allow for more precise injection of content or easier management of the content flow.

This patch add's the required priorities to ensure compatibility with the latest version of primer.

**Requires:** https://github.com/godaddy/wp-primer-theme/pull/146