### PR TITLE
Prevent i10n button overlaps, remove on sale comment, adjust font size for WooCommerce compat.

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -168,6 +168,10 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 }
 
+.woocommerce a.added_to_cart {
+	text-align: left;
+}
+
 body.post-type-archive,
 body.single-product {
 	span.onsale,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -155,9 +155,21 @@
 	}
 }
 
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+	max-width: 100%;
+	white-space: normal;
+	text-align: center;
+	display: block;
+
+	@media #{$large-up} {
+		font-size: 0.75rem;
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -290,10 +290,7 @@ body.woocommerce-cart {
 .woocommerce ul.products li.product a.add_to_cart_button {
 	width: 100%;
 	text-align: center;
-
-	&.product_type_variable {
-		white-space: normal;
-	}
+	white-space: normal;
 }
 
 @media #{$small-only} {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -290,6 +290,10 @@ body.woocommerce-cart {
 .woocommerce ul.products li.product a.add_to_cart_button {
 	width: 100%;
 	text-align: center;
+
+	&.product_type_variable {
+		white-space: normal;
+	}
 }
 
 @media #{$small-only} {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -189,6 +189,16 @@
 		padding: 0.45em;
 	}
 
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
 	table.variations tr:hover td {
 		background-color: transparent;
 	}
@@ -257,19 +267,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
 	text-align: left;
-}
-
-body.post-type-archive,
-body.single-product {
-	span.onsale,
-	ul.products li.product .onsale {
-		padding: 2px 8px;
-		border-radius: 0;
-		margin: 0;
-		min-height: auto;
-		min-width: auto;
-		line-height: inherit;
-	}
 }
 
 body.single-product {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -155,6 +155,93 @@
 	}
 }
 
+.woocommerce-page {
+
+	div.product {
+
+		.woocommerce-product-gallery {
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		.summary {
+			margin-top: 0;
+		}
+
+		.commentlist {
+			padding-left: 0;
+		}
+
+	}
+
+	&.woocommerce div.product form.cart {
+		margin: 1em 0;
+	}
+
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
+
+	.primer-woocommerce .cart .qty {
+		padding: 0.45em;
+	}
+
+	table.variations tr:hover td {
+		background-color: transparent;
+	}
+
+	#reviews #comments ol.commentlist li {
+
+		img.avatar {
+			width: 60px;
+		}
+
+		.comment-text {
+			margin: 0 0 0 80px;
+		}
+
+	}
+
+	form.woocommerce-cart-form {
+
+		table.cart td.actions #coupon_code {
+			width: 50%;
+			margin-right: 0;
+
+		}
+
+	}
+
+	table.cart {
+
+		td.product-thumbnail,
+		td.product-remove {
+			text-align: center;
+
+			@media #{$large-only} {
+				.remove {
+					margin: 0 auto;
+				}
+			}
+		}
+
+		img {
+			width: 100%;
+			max-width: 75px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 6px !important;
+		}
+
+	}
+
+}
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
 	max-width: 100%;
@@ -200,21 +287,6 @@ body.single-product {
 body.woocommerce-cart {
 	.primer-wc-cart-sub-menu {
 		display: none;
-	}
-}
-
-.woocommerce,
-.woocommerce-page {
-	table.cart {
-		img {
-			width: 100%;
-			max-width: 100px;
-			margin-bottom: 0;
-		}
-
-		td.actions .input-text {
-			padding: 6px !important;
-		}
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -210,12 +210,6 @@ function ascension_colors( $colors ) {
 		),
 		'button_color' => array(
 			'default'  => '#00bfff',
-			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
-				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
-					'background-color' => '%1$s',
-				),
-			),
 		),
 		'button_text_color' => array(
 			'default'  => '#ffffff',

--- a/functions.php
+++ b/functions.php
@@ -211,7 +211,8 @@ function ascension_colors( $colors ) {
 		'button_color' => array(
 			'default'  => '#00bfff',
 			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
+				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
 					'background-color' => '%1$s',
 				),
 			),

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4226,6 +4226,16 @@ body.layout-one-column-narrow #content {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.45em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }
 
@@ -4268,18 +4278,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.pr
 
 .woocommerce a.added_to_cart {
   text-align: right; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4219,6 +4219,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.pr
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: right; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4208,20 +4208,28 @@ body.layout-one-column-narrow #content {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4293,6 +4293,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   text-align: center; }
+  .woocommerce ul.products li.product a.add_to_cart_button.product_type_variable {
+    white-space: normal; }
 
 @media only screen and (max-width: 40em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4292,9 +4292,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  text-align: center; }
-  .woocommerce ul.products li.product a.add_to_cart_button.product_type_variable {
-    white-space: normal; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4208,6 +4208,53 @@ body.layout-one-column-narrow #content {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-right: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.45em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 80px 0 0; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 50%;
+  margin-left: 0; }
+
+.woocommerce-page table.cart td.product-thumbnail,
+.woocommerce-page table.cart td.product-remove {
+  text-align: center; }
+  @media only screen and (min-width: 61.063em) and (max-width: 90em) {
+    .woocommerce-page table.cart td.product-thumbnail .remove,
+    .woocommerce-page table.cart td.product-remove .remove {
+      margin: 0 auto; } }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 6px !important; }
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
 .woocommerce a.added_to_cart {
   max-width: 100%;
@@ -4244,16 +4291,6 @@ body.single-product .quantity .input-text {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 6px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -4208,6 +4208,53 @@ body.layout-one-column-narrow #content {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-left: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.45em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 0 0 80px; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 50%;
+  margin-right: 0; }
+
+.woocommerce-page table.cart td.product-thumbnail,
+.woocommerce-page table.cart td.product-remove {
+  text-align: center; }
+  @media only screen and (min-width: 61.063em) and (max-width: 90em) {
+    .woocommerce-page table.cart td.product-thumbnail .remove,
+    .woocommerce-page table.cart td.product-remove .remove {
+      margin: 0 auto; } }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 6px !important; }
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
 .woocommerce a.added_to_cart {
   max-width: 100%;
@@ -4244,16 +4291,6 @@ body.single-product .quantity .input-text {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 6px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -4219,6 +4219,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.pr
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: left; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style.css
+++ b/style.css
@@ -4208,20 +4208,28 @@ body.layout-one-column-narrow #content {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -4226,6 +4226,16 @@ body.layout-one-column-narrow #content {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.45em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }
 
@@ -4268,18 +4278,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.pr
 
 .woocommerce a.added_to_cart {
   text-align: left; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -4293,6 +4293,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   text-align: center; }
+  .woocommerce ul.products li.product a.add_to_cart_button.product_type_variable {
+    white-space: normal; }
 
 @media only screen and (max-width: 40em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {

--- a/style.css
+++ b/style.css
@@ -4292,9 +4292,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  text-align: center; }
-  .woocommerce ul.products li.product a.add_to_cart_button.product_type_variable {
-    white-space: normal; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {


### PR DESCRIPTION
@fjarrett Please review.

Prevent button overlaps, adjust font size for WooCommerce compat.

Additional tweaks for WooCommerce styles. For a complete list see https://github.com/godaddy/wp-primer-theme/pull/182

Related https://github.com/godaddy/wp-primer-theme/pull/167

![example](https://cldup.com/EC9QrDafQc.png)